### PR TITLE
feat(INJI-161): log app id in the access logs

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -149,7 +149,7 @@ server.tomcat.accesslog.prefix=stdout
 server.tomcat.accesslog.buffered=false
 server.tomcat.accesslog.suffix=
 server.tomcat.accesslog.file-date-format=
-server.tomcat.accesslog.pattern={"@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}t","level":"ACCESS","level_value":70000,"traceId":"%{X-B3-TraceId}i","statusCode":%s,"req.requestURI":"%U","bytesSent":%b,"timeTaken":%T,"appName":"${spring.application.name}"}
+server.tomcat.accesslog.pattern={"@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}t","level":"ACCESS","level_value":70000,"traceId":"%{X-B3-TraceId}i","appId":"%{X-AppId}i","statusCode":%s,"req.requestURI":"%U","bytesSent":%b,"timeTaken":%T,"appName":"${spring.application.name}"}
 server.tomcat.accesslog.className=io.mosip.kernel.core.logger.config.SleuthValve
 registration.processor.unMaskedUin.length=5
 


### PR DESCRIPTION
The incoming request's header "X-AppId" will be printed in the access logs as appId. If the request does not have the expected header, hyphen (-) will be printed

Outcome

1. Request sent with expected header

Request
`curl --header "X-AppId: 123456789" http://localhost:8088/v1/mimoto/allProperties`
Log
`{"@timestamp":"2023-07-13T16:03:07.677Z","level":"ACCESS","level_value":70000,"traceId":"-","appId":"123456789","statusCode":200,"req.requestURI":"/v1/mimoto/allProperties","bytesSent":151,"timeTaken":0.011,"appName":"mimoto"}
`

2. Request sent without expected header

Request
`curl http://localhost:8088/v1/mimoto/allProperties`
Log
`{"@timestamp":"2023-07-13T16:05:19.330Z","level":"ACCESS","level_value":70000,"traceId":"-","appId":"-","statusCode":200,"req.requestURI":"/v1/mimoto/allProperties","bytesSent":151,"timeTaken":0.038,"appName":"mimoto"}
`


Issue Link https://mosip.atlassian.net/browse/INJI-161